### PR TITLE
browserslist-to-esbuild（ Chrome 80 未満は切り捨て）

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,1 +1,1 @@
-Chrome >= 1 or Firefox >= 1 and >= 0.2%
+Chrome >= 80 or Firefox >= 1 and >= 0.2%

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,1 +1,2 @@
+# browserslist 的には 79 のシェアが 0.2% いるらしいが、top-level await を使いたいので切り捨てる。
 Chrome >= 80 or Firefox >= 1 and >= 0.2%

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "autoprefixer": "^10.4.14",
     "better-typescript-lib": "^2.2.1",
     "browserslist": "^4.21.5",
+    "browserslist-to-esbuild": "^1.2.0",
     "caniuse-lite": "^1.0.30001509",
     "eslint": "^8.31.0",
     "eslint-config-prettier": "^8.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ devDependencies:
   browserslist:
     specifier: ^4.21.5
     version: 4.21.5
+  browserslist-to-esbuild:
+    specifier: ^1.2.0
+    version: 1.2.0
   caniuse-lite:
     specifier: ^1.0.30001509
     version: 1.0.30001509
@@ -2266,6 +2269,13 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.0.1
+    dev: true
+
+  /browserslist-to-esbuild@1.2.0:
+    resolution: {integrity: sha512-ftrrbI/VHBgEnmnSyhkqvQVMp6jAKybfs0qMIlm7SLBrQTGMsdCIP4q3BoKeLsZTBQllIQtY9kbxgRYV2WU47g==}
+    engines: {node: '>=12'}
+    dependencies:
+      browserslist: 4.21.5
     dev: true
 
   /browserslist@4.21.5:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import type { ManifestV3Export } from '@crxjs/vite-plugin';
 import { crx } from '@crxjs/vite-plugin';
 import react from '@vitejs/plugin-react';
 import autoprefixer from 'autoprefixer';
+import browserslistToEsbuild from 'browserslist-to-esbuild';
 import postcssNested from 'postcss-nested';
 import { visualizer } from 'rollup-plugin-visualizer';
 import { defineConfig, PluginOption } from 'vite';
@@ -39,8 +40,7 @@ export default defineConfig({
         debug: 'debug.html',
       },
     },
-    // for top level await
-    target: 'esnext',
+    target: browserslistToEsbuild(),
   },
 });
 


### PR DESCRIPTION
**Top-Level Await をプラグインレスでもやるために、Chrome 80 未満は切り捨てる。**

browserslist 的には 79 のシェアが堅いんだけど

![image](https://github.com/Cside/hatena-mute/assets/315510/0c6cb458-1b2a-4444-b849-12789843af98)

Sentry 見ても 79 なんておらん。ので切り捨てる。

![image](https://github.com/Cside/hatena-mute/assets/315510/e0f6480e-f64b-4ec7-b881-0d303f904d60)
