### PR TITLE
拡張が更新されても古いタブを開いていた場合、エラー時にリロードを促す

### DIFF
--- a/src/background/main.ts
+++ b/src/background/main.ts
@@ -1,5 +1,6 @@
 import * as sentry from '@sentry/browser';
 import { initSentry } from '../sentry';
+
 import './deleteMutedEntryRegularly';
 import './handleMessages';
 

--- a/src/contentScript/EntryMuter/index.tsx
+++ b/src/contentScript/EntryMuter/index.tsx
@@ -2,7 +2,7 @@
 import type { Entry, StorageKey } from '../../types';
 
 import { ACTION_OF, STORAGE_KEY_OF } from '../../constants';
-import { sendMessage } from '../../sendMessage';
+import { sendMessageToBg } from '../../sendMessage';
 import { storage } from '../../storage';
 import { MuteButtonContainer } from '../components/MuteButtonContainer';
 import { matchesLoosely, replaceUrlsInCss } from './utils';
@@ -89,7 +89,7 @@ export class EntryMuter {
 
   async muteByEntries() {
     const map: Map<string, boolean> = new Map(
-      (await sendMessage({
+      (await sendMessageToBg({
         type: ACTION_OF.GET_MUTED_ENTRY_MAP,
         payload: {
           urls: this.entries.map((entry) => entry.titleLink.href),
@@ -108,7 +108,7 @@ export class EntryMuter {
   }
 
   async muteEntry(url: string) {
-    await sendMessage({
+    await sendMessageToBg({
       type: ACTION_OF.ADD_MUTED_ENTRY,
       payload: { url },
     });

--- a/src/contentScript/EntryMuter/index.tsx
+++ b/src/contentScript/EntryMuter/index.tsx
@@ -17,7 +17,7 @@ export class EntryMuter {
     this.entries = entries;
   }
 
-  async initialize() {
+  initialize() {
     this.injectCss();
     this.appendMuteButtons();
   }

--- a/src/contentScript/VisitedEntryLightener/index.ts
+++ b/src/contentScript/VisitedEntryLightener/index.ts
@@ -1,7 +1,7 @@
 import type { Entry } from '../../types';
 
 import { ACTION_OF, STORAGE_KEY_OF } from '../../constants';
-import { sendMessage } from '../../sendMessage';
+import { sendMessageToBg } from '../../sendMessage';
 import { storage } from '../../storage';
 
 import './styles.pcss';
@@ -59,7 +59,7 @@ export class VisitedEntryLightener {
         const url = new URL(event.target.href);
         if (url.searchParams.has(GA_PARAM)) {
           url.searchParams.delete(GA_PARAM);
-          await sendMessage({
+          await sendMessageToBg({
             type: ACTION_OF.ADD_HISTORY,
             payload: { url: url.toString() },
           });
@@ -97,7 +97,7 @@ export class VisitedEntryLightener {
     // コンストラクタでやると、popup から再呼び出しされたときに、
     // バックグランドで開いた URL の .visited がリセットされてしまうため、都度呼ぶ
     const visitedMap: Map<string, boolean> = new Map(
-      (await sendMessage({
+      (await sendMessageToBg({
         type: ACTION_OF.GET_VISITED_MAP,
         payload: {
           urls: this.entries

--- a/src/contentScript/main.ts
+++ b/src/contentScript/main.ts
@@ -19,7 +19,7 @@ if (rootElement) {
   await extensionEnabler.initialize();
 
   const entryMuter = new EntryMuter({ entries });
-  await entryMuter.initialize();
+  entryMuter.initialize();
 
   const visitedEntryLightener = new VisitedEntryLightener({
     entries,

--- a/src/sendMessage.ts
+++ b/src/sendMessage.ts
@@ -71,6 +71,13 @@ const _sendMessage = async (
             `Maybe the extension is updated but the content script is not reloaded.\n`,
           error,
         );
+
+        if (
+          confirm(
+            '拡張機能が更新されたため、処理に失敗しました。\nリロードします。',
+          )
+        )
+          setTimeout(() => location.reload(), 0);
         throw new AbortError(error);
       }
       addPrefixToError(prefix, error);

--- a/src/sendMessage.ts
+++ b/src/sendMessage.ts
@@ -15,7 +15,7 @@ const addPrefixToError = (prefix: string, error: Error) => {
   error.stack = prefix + error.stack;
 };
 
-const _sendMessage = async (
+const _sendMessageToBg = async (
   attemptNumber: number,
   params: MessageParameters,
 ) => {
@@ -86,12 +86,12 @@ const _sendMessage = async (
   }
 };
 
-export const sendMessage = async (
+export const sendMessageToBg = async (
   params: MessageParameters,
 ): Promise<unknown> =>
   await pRetry(
     (attemptNumber: number) => {
-      return _sendMessage(attemptNumber, params);
+      return _sendMessageToBg(attemptNumber, params);
     },
     // https://github.com/sindresorhus/p-retry#options
     {


### PR DESCRIPTION
`拡張更新したタイミングで、はてブのタブを全部リロード` 案と悩む。
いったん PR だけ作って、考えを寝かす。

https://www.notion.so/cside/Chrome-bg-service-worker-9ce543002dd446e7afca4cfc513bcc5a

<img width="542" alt="image" src="https://github.com/Cside/hatena-mute/assets/315510/4e5644fe-6b21-44dd-8c7f-9ba777c44fc5">